### PR TITLE
Fix java_install to work on Fedora

### DIFF
--- a/roles/jws/tasks/java_install.yml
+++ b/roles/jws/tasks/java_install.yml
@@ -10,4 +10,4 @@
         package_name: "{{tomcat_java_packages_EL}}"
   when:
     - tomcat_java_version is defined
-    - ansible_distribution == "RedHat"
+    - ansible_os_family == "RedHat"


### PR DESCRIPTION
@gzaronikas a small fix to make the java_install also works on Fedora