### PR TITLE
update requires version and tags

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -33,7 +33,7 @@ license_file: "LICENSE"
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
-tags: [java, tomcat, server, apache, jws, mod_cluster]
+tags: [java, tomcat, server, apache, jws, mod_cluster, infrastructure, linux]
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.9.10"


### PR DESCRIPTION
this pr adjusts the tags (adds linux and infrastructure), these are specific to automation hub and help both our SEO as well users to list specific collections by use case (if these don't fit don't hesitate to change them, we just need 1 out of the list of 10 that is below at [0]) 

second change just updates the requires ansible version to `2.9.10`. This patch version was when everything in regards to collections was fully merged into ansible itself, so its better to have that listed. 

[0]
cloud
linux
networking
storage
security
windows
infrastructure
monitoring
tools
database
application