### PR TITLE
Misc: rm invalid vars from name during install

### DIFF
--- a/roles/jws/tasks/install/zipfiles.yml
+++ b/roles/jws/tasks/install/zipfiles.yml
@@ -17,7 +17,7 @@
     - native_zipfile is defined
     - native_zipfile | length > 0
 
-- name: "Install {{ tomcat.service.hr_name }} and required binaries from local zipfiles ({{ item.src }}) to {{ item.creates }} (install method: {{ tomcat.install_method }})"
+- name: "Install {{ tomcat.service.hr_name }} and required binaries from local zipfiles (install method: {{ tomcat.install_method }}"
   unarchive:
     remote_src: yes
     src: "{{ tomcat_install_dir }}/{{ item.src }}"


### PR DESCRIPTION
Fixes [Issue 83](https://github.com/ansible-middleware/jws-ansible-playbook/issues/83)