### PR TITLE
Update playbook to utilize variable defaults

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -18,9 +18,9 @@ skip_list:
   - 204
   - blocked_modules
   - vars_should_not_be_used
+  - role_vars_start_with_role_name
 
 warn_list:
-  - role_vars_start_with_role_name
   - vars_in_vars_files_have_valid_names
   - experimental
   - ignore-errors

--- a/playbook.yml
+++ b/playbook.yml
@@ -16,7 +16,6 @@
     # Use Case 3 - Using JWS, installed from zipfiles, provided in the playbook path or downloaded from RHN (JWS)
     # downloading requires credentials for RHN to be defined: rhn_username and rhn_password
     # tomcat_install_method: rhn_zipfiles
-    # jws_version: 5.6.0
 
     # Use Case 4 - Using JWS RPMs on a RHEL system
     #

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
   vars:
     tomcat_setup: true
 
-    # Use Case 1 - Downloading and Using Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
+    # Use Case 1 - Downloading and Using Apache Tomcat from Apache
     #
     tomcat_install_method: zipfiles
     tomcat_version: 9.0.50

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
   vars:
     tomcat_setup: true
 
-    # Use Case 1 - Download Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
+    # Use Case 1 - Downloading and Using Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
     #
     tomcat_install_method: zipfiles
     tomcat_version: 9.0.50
@@ -17,9 +17,8 @@
     # downloading requires credentials for RHN to be defined: rhn_username and rhn_password
     # tomcat_install_method: rhn_zipfiles
     # jws_version: 5.6.0
-    # tomcat_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
 
-    # Use Case 4 - Using RPM on a RHEL system.
+    # Use Case 4 - Using JWS RPMs on a RHEL system
     #
     # tomcat_install_method: rpm
     # tomcat_home: /opt/rh/root/usr/share/tomcat/

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,11 +7,11 @@
     # Use Case 1 - Download Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
     #
     tomcat_install_method: zipfiles
-    tomcat_version: 9.0.62
+    tomcat_version: 9.0.50
 
     # Use Case 2 - Using Apache Tomcat from local zipfiles
     #
-    # tomcat_version: 9.0.62
+    # tomcat_version: 9.0.50
 
     # Use Case 3 - Using JWS, installed from zipfiles, provided in the playbook path or downloaded from RHN (JWS)
     # downloading requires credentials for RHN to be defined: rhn_username and rhn_password

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,21 +4,19 @@
   vars:
     tomcat_setup: true
 
-    # Use Case 1 - Using Tomcat from apache (uncomment pre-tasks below if download is necessary)
-    tomcat_version: 9.0.50
-    tomcat_home: /opt/apache-tomcat-{{ tomcat_version }}
-    tomcat_download_url: https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split(".")[0] }}/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.zip
-    tomcat_zipfile: "tomcat.zip"
+    # Use Case 1 - Using Apache Tomcat from local zipfiles
+    tomcat_version: 9.0.62
 
-    # Use Case 2 - Download Tomcat from apache
+    # Use Case 2 - Download Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
+    #
     # tomcat_install_method: zipfiles
-    # tomcat_version: 9.0.50
-    # tomcat_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
+    # tomcat_version: 9.0.62
 
     # Use Case 3 - Using JWS, installed from zipfiles, provided in the playbook path or downloaded from RHN (JWS)
     # downloading requires credentials for RHN to be defined: rhn_username and rhn_password
     # tomcat_install_method: rhn_zipfiles
-    # tomcat_home: "{{ tomcat_install_dir }}/jws-5.6/tomcat"
+    # jws_version: 5.6.0
+    # tomcat_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
 
     # Use Case 4 - Using RPM on a RHEL system.
     #
@@ -41,11 +39,3 @@
   roles:
     - redhat_csp_download
     - jws
-
-  pre_tasks:
-    - name: "Pre Tasks: download archive"
-      get_url:
-        url: "{{ tomcat_download_url }}"
-        dest: "{{ tomcat_install_dir }}/{{ tomcat_zipfile }}"
-      when:
-        - tomcat_download_url is defined

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,12 +4,13 @@
   vars:
     tomcat_setup: true
 
-    # Use Case 1 - Using Apache Tomcat from local zipfiles
+    # Use Case 1 - Download Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
+    #
+    tomcat_install_method: zipfiles
     tomcat_version: 9.0.62
 
-    # Use Case 2 - Download Apache Tomcat from Apache (uncomment pre-tasks below if download is necessary)
+    # Use Case 2 - Using Apache Tomcat from local zipfiles
     #
-    # tomcat_install_method: zipfiles
     # tomcat_version: 9.0.62
 
     # Use Case 3 - Using JWS, installed from zipfiles, provided in the playbook path or downloaded from RHN (JWS)

--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -40,10 +40,12 @@ Role Defaults
 |`tomcat_install_method`| Installation method, allowed values: `['local_zipfiles','rhn_zipfiles','zipfiles','rpm']` | `local_zipfiles` |
 |`tomcat_install_dir`| Installation path for JWS/tomcat | `/opt` |
 |`tomcat_rpm`| Installation RPM version | `jws5` |
+|`tomcat_zipfile_home`| Default installation path for tomcat archives | `{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}` |
 |`jws_rhn_base_url`| Customer Portal Base URL for archive download | `https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=` |
 |`jws_version`| Version of JWS to install | `5.6.0` |
 |`jws_apply_patches`| Install JWS most recent cumulative patch for requested version | `False` |
-|`tomcat_home`| Target installation directory | `{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}` |
+|`jws_home`| Default installation path for JWS archives | `{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat` |
+|`tomcat_home`| Target installation directory, defaulting to tomcat or JWS archive path, or can be overridden | `{{ jws_home if tomcat_install_method == 'rhn_zipfiles' else tomcat_zipfile_home }}` |
 |`tomcat_user`| posix user account for service | `tomcat` |
 |`tomcat_uid`| posix UID user account for service | `tomcat` |
 |`tomcat_group`| posix group for service | `tomcat` |

--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -43,13 +43,13 @@ Role Defaults
 |`jws_rhn_base_url`| Customer Portal Base URL for archive download | `https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=` |
 |`jws_version`| Version of JWS to install | `5.6.0` |
 |`jws_apply_patches`| Install JWS most recent cumulative patch for requested version | `False` |
-|`tomcat_home`| Target installation directory | `/opt/jws-5.6/tomcat` |
+|`tomcat_home`| Target installation directory | `{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}` |
 |`tomcat_user`| posix user account for service | `tomcat` |
 |`tomcat_uid`| posix UID user account for service | `tomcat` |
 |`tomcat_group`| posix group for service | `tomcat` |
 |`tomcat_gid`| posix GID user account for service | `tomcat` |
 |`tomcat_zipfile`| Tomcat archive filename | `apache-tomcat-{{ tomcat_version }}.zip` |
-|`tomcat_zipfile_url`| Alternative download URL | `https://dlcdn.apache.org/tomcat/tomcat-9/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}` |
+|`tomcat_zipfile_url`| Alternative download URL | `https://dlcdn.apache.org/tomcat/tomcat-{{ tomcat_version.split(".")[0] }}/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}` |
 |`tomcat_version`| Tomcat version to download | `9.0.60` |
 |`tomcat_force_install`| Whether to stop any running tomcat process and continue installation | `false` |
 

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -9,7 +9,7 @@ jws_version: 5.6.0
 jws_apply_patches: False
 tomcat_version: 9.0.60
 tomcat_zipfile: "apache-tomcat-{{ tomcat_version }}.zip"
-tomcat_zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-9/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
+tomcat_zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
 tomcat_force_install: false
 
 tomcat_user: tomcat
@@ -17,7 +17,7 @@ tomcat_uid: 53
 tomcat_group: tomcat
 tomcat_gid: 53
 
-tomcat_home: '/opt/jws-5.4/tomcat'
+tomcat_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
 tomcat_catalina_base: "{{ lookup('env','CATALINA_BASE') }}"
 tomcat_conf_properties: './conf/catalina.properties'
 tomcat_conf_policy: './conf/catalina.policy'

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -20,7 +20,7 @@ tomcat_zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_ver
 jws_version: 5.6.0
 jws_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
 jws_rhn_base_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=
-# if True automaticcaly apply the most recent cumulative patch
+# if True automatically apply the most recent cumulative patch
 jws_apply_patches: False
 
 tomcat_user: tomcat
@@ -44,12 +44,12 @@ tomcat_conf_templates_web: 'templates/web.xml.j2'
 
 tomcat_shutdown_port: '8005'
 
-# HHTP config
+# HTTP Connector Config
 tomcat_listen_http_port: '8080'
 tomcat_listen_http_bind_address: 'localhost'
 tomcat_listen_http_enabled: 'yes'
 
-# HTTPS listener config
+# HTTPS Connector Config
 tomcat_listen_https_enabled: False
 tomcat_listen_https_port: '8443'
 tomcat_listen_https_bind_address: 'localhost'
@@ -61,7 +61,7 @@ tomcat_listen_https_keystore_file: /etc/ssl/keystore.jks
 tomcat_listen_https_keystore_password: changeit
 tomcat_listen_https_client_auth: false
 
-# tomcat AJP configuration
+# tomcat AJP Connector Config
 tomcat_listen_ajp_enabled: False
 tomcat_listen_ajp_address: '::1'
 tomcat_listen_ajp_port: '8009'

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -1,16 +1,20 @@
 ---
 tomcat_apps_to_remove: 'docs,ROOT,examples'
-tomcat_install_method: local_zipfiles
 tomcat_install_dir: /opt
 tomcat_rpm: jws5
 tomcat_rpm_root_dir: /opt/rh/jws5/
-jws_rhn_base_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=
+tomcat_force_install: false
+
 jws_version: 5.6.0
 jws_apply_patches: False
 tomcat_version: 9.0.60
+jws_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
+jws_rhn_base_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=
+
+tomcat_version: 0.0
+tomcat_catalina_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
 tomcat_zipfile: "apache-tomcat-{{ tomcat_version }}.zip"
 tomcat_zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
-tomcat_force_install: false
 
 tomcat_user: tomcat
 tomcat_uid: 53

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -1,27 +1,36 @@
 ---
+# comma separated list of wars to undeploy
 tomcat_apps_to_remove: 'docs,ROOT,examples'
+# root directory of installation
 tomcat_install_dir: /opt
 tomcat_rpm: jws5
 tomcat_rpm_root_dir: /opt/rh/jws5/
-tomcat_force_install: false
 
-jws_version: 5.6.0
-jws_apply_patches: False
+# if True continue installing even if a running tomcat is found
+tomcat_force_install: False
+
+# installation method: ['local_zipfiles','rhn_zipfiles','zipfiles','rpm']
+tomcat_install_method: local_zipfiles
+
 tomcat_version: 9.0.60
-jws_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
-jws_rhn_base_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=
-
-tomcat_version: 0.0
-tomcat_catalina_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
+tomcat_zipfile_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
 tomcat_zipfile: "apache-tomcat-{{ tomcat_version }}.zip"
 tomcat_zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
+
+jws_version: 5.6.0
+jws_home: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
+jws_rhn_base_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=
+# if True automaticcaly apply the most recent cumulative patch
+jws_apply_patches: False
 
 tomcat_user: tomcat
 tomcat_uid: 53
 tomcat_group: tomcat
 tomcat_gid: 53
 
-tomcat_home: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
+# use default paths for tomcat or jws zipfiles depending on install_method; or can be overriden
+tomcat_home: "{{ jws_home if tomcat_install_method == 'rhn_zipfiles' else tomcat_zipfile_home }}"
+
 tomcat_catalina_base: "{{ lookup('env','CATALINA_BASE') }}"
 tomcat_conf_properties: './conf/catalina.properties'
 tomcat_conf_policy: './conf/catalina.policy'
@@ -29,16 +38,18 @@ tomcat_conf_loggging: './conf/logging.properties'
 tomcat_conf_context: './conf/context.xml'
 tomcat_conf_server: './conf/server.xml'
 tomcat_conf_web: './conf/web.xml'
-
 tomcat_conf_templates_context: 'templates/context.xml.j2'
 tomcat_conf_templates_server: 'templates/server.xml.j2'
 tomcat_conf_templates_web: 'templates/web.xml.j2'
+
 tomcat_shutdown_port: '8005'
 
+# HHTP config
 tomcat_listen_http_port: '8080'
 tomcat_listen_http_bind_address: 'localhost'
 tomcat_listen_http_enabled: 'yes'
 
+# HTTPS listener config
 tomcat_listen_https_enabled: False
 tomcat_listen_https_port: '8443'
 tomcat_listen_https_bind_address: 'localhost'
@@ -50,12 +61,14 @@ tomcat_listen_https_keystore_file: /etc/ssl/keystore.jks
 tomcat_listen_https_keystore_password: changeit
 tomcat_listen_https_client_auth: false
 
+# tomcat AJP configuration
 tomcat_listen_ajp_enabled: False
 tomcat_listen_ajp_address: '::1'
 tomcat_listen_ajp_port: '8009'
 tomcat_listen_ajp_secretRequired: 'True'
 tomcat_listen_ajp_secret: 'secret'
 
+# vault configuration
 tomcat_vault_name: 'vault.keystore'
 tomcat_vault_enable: 'False'
 tomcat_vault_alias: 'my_vault'
@@ -64,16 +77,18 @@ tomcat_vault_iteration: '44'
 tomcat_vault_salt: '1234abcd'
 tomcat_vault_properties: '/conf/vault.properties'
 
+# modcluster configuration
 tomcat_modcluster_enable: 'False'
 tomcat_modcluster_ip: '127.0.0.1'
 tomcat_modcluster_port: '6666'
 tomcat_modcluster_connector_port: '6666'
 tomcat_modcluster_advertise: 'false'
-
+# modcluster session configuration
 tomcat_modcluster_stickySession: 'true'
 tomcat_modcluster_stickySessionForce: 'false'
 tomcat_modcluster_stickySessionRemove: 'true'
 
+# systemd/service settings
 tomcat_systemd_enabled: 'False'
 tomcat_systemd_script_interpreter: 'bash'
 tomcat_systemd_script_shebang: "#!/bin/{{ tomcat_systemd_script_interpreter }}"

--- a/roles/jws/meta/argument_specs.yml
+++ b/roles/jws/meta/argument_specs.yml
@@ -36,6 +36,11 @@ argument_specs:
                 default: "5.6.0"
                 description: "Version of JWS to install"
                 type: "str"
+            jws_home:
+                # line 19 of jws/defaults/main.yml
+                default: "{{ tomcat_install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
+                description: "Default installation path for JWS archives"
+                type: "str"
             jws_apply_patches:
                 default: False
                 description: "Install JWS most recent cumulative patch for requested version"
@@ -77,9 +82,14 @@ argument_specs:
                 default: "53"
                 description: "posix group GID for service"
                 type: "int"
-            tomcat_home:
+            tomcat_zipfile_home:
                 # line 9 of jws/defaults/main.yml
                 default: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
+                description: "Default target installation directory for tomcat zipfile"
+                type: "str"
+            tomcat_home:
+                # line 9 of jws/defaults/main.yml
+                default: "{{ jws_home if tomcat_install_method == 'rhn_zipfiles' else tomcat_zipfile_home }}"
                 description: "Target installation directory"
                 type: "str"
             tomcat_catalina_base:

--- a/roles/jws/meta/argument_specs.yml
+++ b/roles/jws/meta/argument_specs.yml
@@ -52,7 +52,7 @@ argument_specs:
                 type: "str"
             tomcat_zipfile_url:
                 # line 7 of jws/defaults/main.yml
-                default: "https://dlcdn.apache.org/tomcat/tomcat-9/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
+                default: "https://dlcdn.apache.org/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/{{ tomcat_zipfile }}"
                 description: "Custom URL for tomcat/jws archive download"
                 type: "str"
             tomcat_user:
@@ -79,7 +79,7 @@ argument_specs:
                 type: "int"
             tomcat_home:
                 # line 9 of jws/defaults/main.yml
-                default: "/opt/jws-5.4/tomcat"
+                default: "{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}"
                 description: "Target installation directory"
                 type: "str"
             tomcat_catalina_base:

--- a/roles/jws/tasks/uninstall.yml
+++ b/roles/jws/tasks/uninstall.yml
@@ -21,7 +21,7 @@
           - tomcat.home is defined
         quiet: true
 
-    - name: "Deletes files from server home {{ tomcat.home }}"
+    - name: "Delete files from server home {{ tomcat.home }}"
       file:
         path: "{{ tomcat.home }}"
         state: absent

--- a/roles/jws/vars/main.yml
+++ b/roles/jws/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 tomcat:
   supported_install_method: [local_zipfiles, rhn_zipfiles, zipfiles, rpm]
-  install_method: "{{ tomcat_install_method }}"
+  install_method: "{{ tomcat_install_method if tomcat_install_method is defined else 'rhn_zipfiles' if tomcat_version == 0.0 else 'local_zipfiles' }}"
   install_dir: "{{ tomcat_install_dir }}"
   rpm: "{{ tomcat_rpm }}"
   rpm_root_dir: "{{ tomcat_rpm_root_dir }}"
@@ -16,7 +16,7 @@ tomcat:
   uid: "{{ tomcat_uid }}"
   group: "{{ tomcat_group }}"
   gid: "{{ tomcat_gid }}"
-  home: "{{ tomcat_home }}"
+  home: "{{ jws_home if tomcat_version == 0.0 else tomcat_catalina_home }}"
   base: "{{ tomcat_catalina_base }}"
   conf:
     properties: "{{ tomcat_conf_properties  }}"
@@ -85,7 +85,7 @@ tomcat:
     systemd: "{{ tomcat_service_systemd }}"
     pidfile: "{{ tomcat_service_systemd_pidfile }}"
     type: "{{ tomcat_service_systemd_type }}"
-    hr_name: "{{ 'Jboss Web Server' if tomcat_install_method in ['rhn_zipfiles','rpm'] else 'Tomcat' }}"
+    hr_name: "{{ 'Jboss Web Server' if tomcat_install_method is defined and tomcat_install_method in ['rhn_zipfiles','rpm'] else 'Tomcat' }}"
 
 jws:
   rhn_ids:

--- a/roles/jws/vars/main.yml
+++ b/roles/jws/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 tomcat:
   supported_install_method: [local_zipfiles, rhn_zipfiles, zipfiles, rpm]
-  install_method: "{{ tomcat_install_method if tomcat_install_method is defined else 'rhn_zipfiles' if tomcat_version == 0.0 else 'local_zipfiles' }}"
+  install_method: "{{ tomcat_install_method }}"
   install_dir: "{{ tomcat_install_dir }}"
   rpm: "{{ tomcat_rpm }}"
   rpm_root_dir: "{{ tomcat_rpm_root_dir }}"
@@ -16,7 +16,7 @@ tomcat:
   uid: "{{ tomcat_uid }}"
   group: "{{ tomcat_group }}"
   gid: "{{ tomcat_gid }}"
-  home: "{{ jws_home if tomcat_version == 0.0 else tomcat_catalina_home }}"
+  home: "{{ tomcat_home }}"
   base: "{{ tomcat_catalina_base }}"
   conf:
     properties: "{{ tomcat_conf_properties  }}"


### PR DESCRIPTION
Update playbook to be simpler and rely on defaults rather than requiring settings
Remove download pre-task since zipfiles method does that for you
Switch tomcat_home default from jws to apache tomcat file location (in line with other defaults)
Update tomcat_zipfile_url defaults to use the split which is more dynamic