### PR TITLE
First pass at removing redhat_csp_download collection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,6 @@ Plugins and modules within a collection may be tested with only specific Ansible
 <!--end requires_ansible-->
 
 
-### Dependencies
-
-- `middleware_automation.redhat_csp_download`
-    - This collection is required to download resources from Red Hat Customer Portal.
-    - Documentation for the collection can be found at <https://github.com/ansible-middleware/redhat-csp-download>
-
-
 ## Included content
 
 ### Roles
@@ -41,7 +34,6 @@ The use of the playbook will vary on the installation method you choose. The fol
 
 - local zipfile
 - rpm
-- using your RHN credentials to retrieve the JWS zipfiles provided by Red Hat
 - setting a custom URL for downloading the tomcat/JWS archives
 
 
@@ -73,11 +65,6 @@ To use JWS, set the install method to rhn_zipfiles:
     vars:
        ...
        tomcat_install_method: rhn_zipfiles
-
-To automatically download the JWS archives from Red Hat Customer Portal, provide your RHN credentials (as extra argument, in variable file, or better loaded from vault):
-
-    rhn_username: alice@wonderland.org
-    rhn_password: eatmeiamacookie
 
 
 ### Using JWS local zipfiles

--- a/docs/_gh_include/header.inc
+++ b/docs/_gh_include/header.inc
@@ -29,7 +29,6 @@
             <li class="toctree-l1"><a class="reference internal" href="https://ansible-middleware.github.io/wildfly/">Wildfly / Red Hat JBoss EAP</a></li>
             <li class="toctree-l1"><a class="reference internal" href="https://ansible-middleware.github.io/jws-ansible-playbook/">Tomcat / Red Hat JWS</a></li>
             <li class="toctree-l1"><a class="reference internal" href="https://ansible-middleware.github.io/amq/">ActiveMQ / Red Hat AMQ</a></li>
-            <li class="toctree-l1"><a class="reference internal" href="https://ansible-middleware.github.io/redhat-csp-download/">Red Hat CSP Download</a></li>
             <li class="toctree-l1"><a class="reference internal" href="https://ansible-middleware.github.io/ansible_collections_jcliff/">JCliff</a></li>
           </ul>
         </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,5 +34,4 @@ Welcome to JWS Collection documentation
    Wildfly / Red Hat JBoss EAP <https://ansible-middleware.github.io/wildfly/>
    Tomcat / Red Hat JWS <https://ansible-middleware.github.io/jws-ansible-playbook/>
    ActiveMQ / Red Hat AMQ <https://ansible-middleware.github.io/amq/>
-   Red Hat CSP Download <https://ansible-middleware.github.io/redhat-csp-download/>
    JCliff <https://ansible-middleware.github.io/ansible_collections_jcliff/>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,8 +12,6 @@ authors:
 description: This collection contains the ansible playbook to setup JWS.
 license_file: "LICENSE"
 tags: [java, tomcat, server, apache, jws, modcluster, infrastructure, linux]
-dependencies:
-  middleware_automation.redhat_csp_download: '>=1.2.1'
 repository: https://github.com/ansible-middleware/jws-ansible-playbook
 documentation: https://ansible-middleware.github.io/jws-ansible-playbook
 homepage: https://github.com/ansible-middleware/jws-ansible-playbook

--- a/molecule/ajp_or_https/converge.yml
+++ b/molecule/ajp_or_https/converge.yml
@@ -4,10 +4,6 @@
   become: true
   vars_files:
     - vars.yml
-  collections:
-    - middleware_automation.redhat_csp_download
   tasks:
-    - ansible.builtin.include_role:
-        name: redhat_csp_download
     - ansible.builtin.include_role:
         name: jws

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -35,10 +35,7 @@
     # workaround issue on Github actions
     ansible_distribution: 'RedHat'
   collections:
-    - middleware_automation.redhat_csp_download
     - middleware_automation.jws
   tasks:
-    - ansible.builtin.include_role:
-        name: redhat_csp_download
     - ansible.builtin.include_role:
         name: jws

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  - middleware_automation.redhat_csp_download
   - name: community.general
   - name: community.docker
     version: ">=1.9.1"

--- a/molecule/rpm/converge.yml
+++ b/molecule/rpm/converge.yml
@@ -13,10 +13,6 @@
 
     # workaround issue on Github actions
     ansible_distribution: 'RedHat'
-  collections:
-    - middleware_automation.redhat_csp_download
-  roles:
-    - redhat_csp_download
   tasks:
     - ansible.builtin.include_role:
         name: jws

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -4,10 +4,6 @@
   become: true
   vars_files:
     - vars.yml
-  collections:
-    - middleware_automation.redhat_csp_download
   tasks:
-    - ansible.builtin.include_role:
-        name: redhat_csp_download
     - ansible.builtin.include_role:
         name: jws

--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -4,13 +4,6 @@ middleware_automation.jws.jws
 This role contains the ansible playbook to setup JWS.
 
 
-Dependency
---------------
-- middleware_automation.redhat_csp_download
-    - This collection is required to download resources from RedHat Customer Portal.
-    - Documentation to collection can be found at <https://github.com/ansible-middleware/redhat-csp-download>
-
-
 Versions
 --------
 

--- a/roles/jws/meta/main.yml
+++ b/roles/jws/meta/main.yml
@@ -1,7 +1,4 @@
 ---
-collections:
-  - middleware_automation.redhat_csp_download
-
 galaxy_info:
   role_name: jws
   namespace: middleware_automation

--- a/roles/jws/tasks/apply_cp.yml
+++ b/roles/jws/tasks/apply_cp.yml
@@ -57,34 +57,6 @@
     path: "{{ patch_native_archive }}"
   register: patch_native_archive_path
 
-- name: Perform patch download from RHN
-  middleware_automation.redhat_csp_download.redhat_csp_download:
-    url: "{{ tomcat.rhn.cpatch_zipfile_url }}"
-    dest: "{{ local_path.stat.path }}/{{ tomcat.rhn.patch_bundle }}"
-    username: "{{ rhn_username }}"
-    password: "{{ rhn_password }}"
-  no_log: "{{ omit_rhn_output | default(true) }}"
-  delegate_to: localhost
-  when:
-    - patch_archive_path is defined
-    - patch_archive_path.stat is defined
-    - not patch_archive_path.stat.exists
-    - not local_archive_path.stat.exists
-
-- name: Perform native patch download from RHN
-  middleware_automation.redhat_csp_download.redhat_csp_download:
-    url: "{{ tomcat.rhn.cpatch_native_zipfile_url }}"
-    dest: "{{ local_path.stat.path }}/{{ patch_native_bundle }}"
-    username: "{{ rhn_username }}"
-    password: "{{ rhn_password }}"
-  no_log: "{{ omit_rhn_output | default(true) }}"
-  delegate_to: localhost
-  when:
-    - patch_native_archive_path is defined
-    - patch_native_archive_path.stat is defined
-    - not patch_native_archive_path.stat.exists
-    - not local_native_archive_path.stat.exists
-
 ## copy and unpack
 - name: Copy patch archive to target nodes
   ansible.builtin.copy:

--- a/roles/jws/tasks/install/fetch_zipfile_from_rhn_and_deploy.yml
+++ b/roles/jws/tasks/install/fetch_zipfile_from_rhn_and_deploy.yml
@@ -26,18 +26,6 @@
   register: local_archive_path
   delegate_to: localhost
 
-- name: "Install JWS with zipfile from RHN: {{ zipfile_url }}"
-  redhat_csp_download:
-    url: "{{ zipfile_url }}"
-    dest: "{{ zipfile }}"
-    username: "{{ tomcat.rhn.username }}"
-    password: "{{ tomcat.rhn.password }}"
-  delegate_to: localhost
-  register: new_version_downloaded
-  when:
-    - not archive_path.stat.exists
-    - not local_archive_path.stat.exists
-
 - name: "Copy archives to target nodes: {{ tomcat_install_dir }}/{{ zipfile }}"
   ansible.builtin.copy:
     src: "{{ local_path.stat.path }}/{{ zipfile }}"


### PR DESCRIPTION
We may be able to remove some (or all?) of the RHN logic too and just use a single tasks that is controlled with variables...