### PR TITLE
Conditionally install openssl and apr, only when tomcat-native is installed

### DIFF
--- a/roles/jws/tasks/main.yml
+++ b/roles/jws/tasks/main.yml
@@ -12,8 +12,15 @@
   loop:
     - zip
     - unzip
+
+- name: "Install required dependencies for natives"
+  include_tasks: fastpackage.yml
+  vars:
+    package_name: "{{ item }}"
+  loop:
     - openssl
     - apr
+  when: jws_native
 
 - name: "Ensure tomcatjss rpm is not installed"
   ansible.builtin.dnf:


### PR DESCRIPTION
It's not saving much, but you don't need apr or openssl unless you're using tomcat-native, so we can skip them unless the tomcat-native variable is set.