### PR TITLE
Update modcluster connector port default

### DIFF
--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -103,7 +103,7 @@ Role Defaults
 |`jws_modcluster_enable`| Enable mod_cluster module | `False` |
 |`jws_modcluster_ip`| Bind address for mod_cluster | `127.0.0.1` |
 |`jws_modcluster_port`| mod_cluster port | `6666` |
-|`jws_modcluster_connector_port`| mod_cluster connector port | `6666` |
+|`jws_modcluster_connector_port`| mod_cluster connector port | `8080` |
 |`jws_modcluster_advertise`| Enable mod_cluster advertising | `false` |
 |`jws_modcluster_sticky_session`| Enable mod_cluster sticky sessions | `true` |
 |`jws_modcluster_sticky_session_force`| Force use of sticky sessions | `false` |

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -85,7 +85,7 @@ jws_tomcat_vault_data: 'VAULT.dat'
 jws_modcluster_enabled: False
 jws_modcluster_ip: '127.0.0.1'
 jws_modcluster_port: '6666'
-jws_modcluster_connector_port: '6666'
+jws_modcluster_connector_port: '8080'
 jws_modcluster_advertise: 'false'
 # modcluster session configuration
 jws_modcluster_sticky_session: True


### PR DESCRIPTION
The connectorPort for modcluster should be one of the connectors from Tomcat rather than the management port for modcluster, by default we set the HTTP connector since it's the only default connector available