### PR TITLE
ci: Run CI on pushes to all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 name: CI
 on:
   push:
-    branches:
-      - main
   pull_request:
   schedule:
     - cron: '0 6 * * *'


### PR DESCRIPTION
It's imho better to find potential issues before creating a PR. And development in the `main` branch is not ideal (definitely not for any bigger changes...)