### PR TITLE
Stop running docs and traffic stats jobs in forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   docs:
+    if: ${{ github.repository == 'ansible-middleware/jws' }}
     uses: ansible-middleware/github-actions/.github/workflows/docs.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   traffic:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ansible-middleware/jws' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
It keeps failing as it's not intended to be run in forks. Disabling it will save contributors from at least some e-mails. 